### PR TITLE
Fix MapById::lower_bound function and implement test to reproduce the bug

### DIFF
--- a/cartographer/mapping/id.h
+++ b/cartographer/mapping/id.h
@@ -378,22 +378,27 @@ class MapById {
 
     const std::map<int, DataType>& trajectory =
         trajectories_.at(trajectory_id).data_;
+
     if (internal::GetTime(std::prev(trajectory.end())->second) < time) {
       return EndOfTrajectory(trajectory_id);
     }
-    auto left = trajectory.begin();
-    auto right = std::prev(trajectory.end());
+
+    size_t left = 0;
+    size_t right = trajectory.size() - 1;
     while (left != right) {
-      const int middle = left->first + (right->first - left->first) / 2;
-      const auto lower_bound_middle = trajectory.lower_bound(middle);
-      if (internal::GetTime(lower_bound_middle->second) < time) {
-        left = std::next(lower_bound_middle);
+      const int middle_index = (left + right) / 2;
+      auto middle = trajectory.begin();
+      std::advance(middle, middle_index);
+
+      if (internal::GetTime(middle->second) < time) {
+        left = middle_index + 1;
       } else {
-        right = lower_bound_middle;
+        right = middle_index;
       }
     }
-
-    return ConstIterator(*this, IdType{trajectory_id, left->first});
+    auto result = trajectory.begin();
+    std::advance(result, left);
+    return ConstIterator(*this, IdType{trajectory_id, result->first});
   }
 
  private:

--- a/cartographer/mapping/id_test.cc
+++ b/cartographer/mapping/id_test.cc
@@ -284,8 +284,10 @@ TEST(IdTest, LowerBoundTrimmedTrajectory) {
   std::advance(trim_segment_end,
                trim_segment_start_index + trim_segment_length);
 
-  for (auto it = trim_segment_start; it != trim_segment_end; ++it) {
-    map_by_id.Trim(it->id);
+  for (auto it = trim_segment_start; it != trim_segment_end;) {
+    const auto this_it = it;
+    ++it;
+    map_by_id.Trim(this_it->id);
   }
 
   auto it = map_by_id.lower_bound(kTrajectoryId, CreateTime(0));

--- a/cartographer/mapping/id_test.cc
+++ b/cartographer/mapping/id_test.cc
@@ -275,7 +275,7 @@ TEST(IdTest, LowerBoundTrimmedTrajectory) {
   // Choose random start for a trim_segment.
   std::uniform_int_distribution<int> dt_trim_segment_start(
       2, N - trim_segment_length - 1);
-  auto trim_segment_start_index = dt_trim_segment_start(rng);
+  size_t trim_segment_start_index = dt_trim_segment_start(rng);
 
   auto trim_segment_start = map_by_id.begin();
   std::advance(trim_segment_start, trim_segment_start_index);

--- a/cartographer/mapping/id_test.cc
+++ b/cartographer/mapping/id_test.cc
@@ -117,7 +117,8 @@ TEST(IdTest, MapByIdIterator) {
 TEST(IdTest, MapByIdTrajectoryRange) {
   MapById<NodeId, int> map_by_id = CreateTestMapById<NodeId>();
   std::deque<std::pair<NodeId, int>> expected_data = {
-      {NodeId{0, 0}, 0}, {NodeId{0, 1}, 1},
+      {NodeId{0, 0}, 0},
+      {NodeId{0, 1}, 1},
   };
   for (const auto& entry : map_by_id.trajectory(0)) {
     ASSERT_FALSE(expected_data.empty());
@@ -268,31 +269,32 @@ TEST(IdTest, LowerBoundTrimmedTrajectory) {
   }
 
   // Choose random length of a trim segment.
-  std::uniform_int_distribution<int> dt_trim_segment_length(1, static_cast<int>(N / 2));
+  std::uniform_int_distribution<int> dt_trim_segment_length(
+      1, static_cast<int>(N / 2));
   size_t trim_segment_length = dt_trim_segment_length(rng);
   // Choose random start for a trim_segment.
-  std::uniform_int_distribution<int> dt_trim_segment_start(2, N - trim_segment_length - 1);
+  std::uniform_int_distribution<int> dt_trim_segment_start(
+      2, N - trim_segment_length - 1);
   auto trim_segment_start_index = dt_trim_segment_start(rng);
 
   auto trim_segment_start = map_by_id.begin();
   std::advance(trim_segment_start, trim_segment_start_index);
 
   auto trim_segment_end = map_by_id.begin();
-  std::advance(trim_segment_end, trim_segment_start_index + trim_segment_length);
+  std::advance(trim_segment_end,
+               trim_segment_start_index + trim_segment_length);
 
-
-  for (auto it = trim_segment_start; it != trim_segment_end; ++it){
+  for (auto it = trim_segment_start; it != trim_segment_end; ++it) {
     map_by_id.Trim(it->id);
   }
 
   auto it = map_by_id.lower_bound(kTrajectoryId, CreateTime(0));
 
-  auto ground_truth = std::lower_bound(
-      map_by_id.BeginOfTrajectory(kTrajectoryId),
-      map_by_id.EndOfTrajectory(kTrajectoryId), CreateTime(0),
-      [](MapById<SubmapId, Data>::IdDataReference a, const common::Time& t) {
-        return a.data.time() < t;
-      });
+  auto ground_truth =
+      std::lower_bound(map_by_id.BeginOfTrajectory(kTrajectoryId),
+                       map_by_id.EndOfTrajectory(kTrajectoryId), CreateTime(0),
+                       [](MapById<SubmapId, Data>::IdDataReference a,
+                          const common::Time& t) { return a.data.time() < t; });
 
   EXPECT_EQ(ground_truth, it);
 }


### PR DESCRIPTION
This fixes the bug that has been faced during localization with an initial pose and a trimmed map (OverlappingSubmapsTrimmer2D has been used). A small test is added that reproduces the problem (an infinite loop) where a trimmed trajectory (MapById instance) is used.

