### PR TITLE
Fix build status on front page.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ configurations.
 
 |video|
 
-.. _Cartographer: https://github.com/googlecartographer/cartographer
+.. _Cartographer: https://github.com/cartographer-project/cartographer
 .. _SLAM: https://en.wikipedia.org/wiki/Simultaneous_localization_and_mapping
 
 Getting started
@@ -37,7 +37,7 @@ Getting started
 * You can ask a question by `creating an issue`_.
 
 .. _our Read the Docs site: https://google-cartographer.readthedocs.io
-.. _creating an issue: https://github.com/googlecartographer/cartographer_ros/issues/new?labels=question
+.. _creating an issue: https://github.com/cartographer-project/cartographer_ros/issues/new?labels=question
 
 Contributing
 ============
@@ -45,7 +45,7 @@ Contributing
 You can find information about contributing to Cartographer at `our Contribution
 page`_.
 
-.. _our Contribution page: https://github.com/googlecartographer/cartographer/blob/master/CONTRIBUTING.md
+.. _our Contribution page: https://github.com/cartographer-project/cartographer/blob/master/CONTRIBUTING.md
 
 Open house slide archive
 ========================
@@ -83,10 +83,10 @@ Slides of these Cartographer Open House meetings are listed below.
 - June 22, 2017: `Slides <https://storage.googleapis.com/cartographer-public-data/cartographer-open-house/170622/sildes.pdf>`_
 - June 8, 2017: `Slides <https://storage.googleapis.com/cartographer-public-data/cartographer-open-house/170608/slides.pdf>`_
 
-.. |build| image:: https://travis-ci.org/googlecartographer/cartographer.svg?branch=master
+.. |build| image:: https://travis-ci.org/cartographer-project/cartographer.svg?branch=master
     :alt: Build Status
     :scale: 100%
-    :target: https://travis-ci.org/googlecartographer/cartographer
+    :target: https://travis-ci.org/cartographer-project/cartographer
 .. |docs| image:: https://readthedocs.org/projects/google-cartographer/badge/?version=latest
     :alt: Documentation Status
     :scale: 100%
@@ -94,7 +94,7 @@ Slides of these Cartographer Open House meetings are listed below.
 .. |license| image:: https://img.shields.io/badge/License-Apache%202.0-blue.svg
      :alt: Apache 2 license.
      :scale: 100%
-     :target: https://github.com/googlecartographer/cartographer/blob/master/LICENSE
+     :target: https://github.com/cartographer-project/cartographer/blob/master/LICENSE
 .. |video| image:: https://j.gifs.com/wp3BJM.gif
     :alt: Cartographer 3D SLAM Demo
     :scale: 100%

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -5,7 +5,7 @@ Steps for Releasing
   catkin_generate_changelog
 
 * Update changelog to point to GitHub release log (e.g.
-  https://github.com/googlecartographer/cartographer/compare/0.1.0...0.2.0)
+  https://github.com/cartographer-project/cartographer/compare/0.1.0...0.2.0)
 
 .. code-block:: bash
   git commit -am"Update changelog for release"

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -260,7 +260,7 @@ def cartographer_repositories():
         sha256 = "83c2a27c92979787f38810adc4b6bb67aa09607c53dbadca3430a5f29e0a1cd3",
         strip_prefix = "async_grpc-771af45374af7f7bfc3b622ed7efbe29a4aba403",
         urls = [
-            "https://github.com/googlecartographer/async_grpc/archive/771af45374af7f7bfc3b622ed7efbe29a4aba403.tar.gz",
+            "https://github.com/cartographer-project/async_grpc/archive/771af45374af7f7bfc3b622ed7efbe29a4aba403.tar.gz",
         ],
     )
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,7 +30,7 @@ Cartographer
 and mapping (`SLAM`_) in 2D and 3D across multiple platforms and sensor
 configurations.
 
-.. _Cartographer: https://github.com/googlecartographer/cartographer
+.. _Cartographer: https://github.com/cartographer-project/cartographer
 .. _SLAM: https://en.wikipedia.org/wiki/Simultaneous_localization_and_mapping
 
 Technical Overview
@@ -38,7 +38,7 @@ Technical Overview
 * High level system overview of Cartographer
 
 .. image:: high_level_system_overview.png
-     :target: https://github.com/googlecartographer/cartographer/blob/master/docs/source/high_level_system_overview.png
+     :target: https://github.com/cartographer-project/cartographer/blob/master/docs/source/high_level_system_overview.png
 
 .. To make modifications, edit the original Google Sketch and export a png.
 .. https://docs.google.com/drawings/d/1kCJ_dEbSvV83THCUfMikCPw7xFrTkrvRw5r6Ji8C90c/edit?usp=sharing
@@ -56,7 +56,7 @@ ROS integration is provided by the `Cartographer ROS repository`_. You will find
 complete documentation for using Cartographer with ROS at the
 `Cartographer ROS Read the Docs site`_.
 
-.. _Cartographer ROS repository: https://github.com/googlecartographer/cartographer_ros
+.. _Cartographer ROS repository: https://github.com/cartographer-project/cartographer_ros
 .. _Cartographer ROS Read the Docs site: https://google-cartographer-ros.readthedocs.io
 
 Getting started without ROS

--- a/docs/source/pbstream_migration.rst
+++ b/docs/source/pbstream_migration.rst
@@ -33,5 +33,5 @@ The tool assumes that the first pbstream provided as commandline argument,
 follows the serialization format of Cartographer 0.3. The resulting
 1.0 pbstream will be saved to the second commandline argument location.
 
-.. _RFC-0021: https://github.com/googlecartographer/rfcs/blob/master/text/0021-serialization-format.md
-.. _source: https://github.com/googlecartographer/cartographer/blob/master/cartographer/io/pbstream_main.cc
+.. _RFC-0021: https://github.com/cartographer-project/rfcs/blob/master/text/0021-serialization-format.md
+.. _source: https://github.com/cartographer-project/cartographer/blob/master/cartographer/io/pbstream_main.cc

--- a/package.xml
+++ b/package.xml
@@ -28,7 +28,7 @@
   </maintainer>
   <license>Apache 2.0</license>
 
-  <url>https://github.com/googlecartographer/cartographer</url>
+  <url>https://github.com/cartographer-project/cartographer</url>
 
   <author email="google-cartographer@googlegroups.com">
     The Cartographer Authors

--- a/scripts/install_async_grpc.sh
+++ b/scripts/install_async_grpc.sh
@@ -17,7 +17,7 @@
 set -o errexit
 set -o verbose
 
-git clone https://github.com/googlecartographer/async_grpc
+git clone https://github.com/cartographer-project/async_grpc
 cd async_grpc
 git checkout 771af45374af7f7bfc3b622ed7efbe29a4aba403
 mkdir build


### PR DESCRIPTION
Changes "googlecartographer" to "cartographer-project"
for references to CI and GitHub.