### PR TITLE
Fix typo, naming, formatting, type.

### DIFF
--- a/cartographer/io/min_max_range_filtering_points_processor.cc
+++ b/cartographer/io/min_max_range_filtering_points_processor.cc
@@ -23,26 +23,29 @@
 namespace cartographer {
 namespace io {
 
-std::unique_ptr<MinMaxRangeFiteringPointsProcessor>
-MinMaxRangeFiteringPointsProcessor::FromDictionary(
+std::unique_ptr<MinMaxRangeFilteringPointsProcessor>
+MinMaxRangeFilteringPointsProcessor::FromDictionary(
     common::LuaParameterDictionary* const dictionary,
     PointsProcessor* const next) {
-  return absl::make_unique<MinMaxRangeFiteringPointsProcessor>(
+  return absl::make_unique<MinMaxRangeFilteringPointsProcessor>(
       dictionary->GetDouble("min_range"), dictionary->GetDouble("max_range"),
       next);
 }
 
-MinMaxRangeFiteringPointsProcessor::MinMaxRangeFiteringPointsProcessor(
+MinMaxRangeFilteringPointsProcessor::MinMaxRangeFilteringPointsProcessor(
     const double min_range, const double max_range, PointsProcessor* next)
-    : min_range_squared_(min_range*min_range), max_range_squared_(max_range*max_range),
+    : min_range_squared_(min_range * min_range),
+      max_range_squared_(max_range * max_range),
       next_(next) {}
 
-void MinMaxRangeFiteringPointsProcessor::Process(
+void MinMaxRangeFilteringPointsProcessor::Process(
     std::unique_ptr<PointsBatch> batch) {
   absl::flat_hash_set<int> to_remove;
   for (size_t i = 0; i < batch->points.size(); ++i) {
-    const float range = (batch->points[i].position - batch->origin).squaredNorm();
-    if (!(min_range_squared_ <= range && range <= max_range_squared_)) {
+    const float range_squared =
+        (batch->points[i].position - batch->origin).squaredNorm();
+    if (!(min_range_squared_ <= range_squared &&
+          range_squared <= max_range_squared_)) {
       to_remove.insert(i);
     }
   }
@@ -50,7 +53,7 @@ void MinMaxRangeFiteringPointsProcessor::Process(
   next_->Process(std::move(batch));
 }
 
-PointsProcessor::FlushResult MinMaxRangeFiteringPointsProcessor::Flush() {
+PointsProcessor::FlushResult MinMaxRangeFilteringPointsProcessor::Flush() {
   return next_->Flush();
 }
 

--- a/cartographer/io/min_max_range_filtering_points_processor.h
+++ b/cartographer/io/min_max_range_filtering_points_processor.h
@@ -27,21 +27,21 @@ namespace io {
 
 // Filters all points that are farther away from their 'origin' as 'max_range'
 // or closer than 'min_range'.
-class MinMaxRangeFiteringPointsProcessor : public PointsProcessor {
+class MinMaxRangeFilteringPointsProcessor : public PointsProcessor {
  public:
   constexpr static const char* kConfigurationFileActionName =
       "min_max_range_filter";
-  MinMaxRangeFiteringPointsProcessor(double min_range, double max_range,
-                                     PointsProcessor* next);
-  static std::unique_ptr<MinMaxRangeFiteringPointsProcessor> FromDictionary(
+  MinMaxRangeFilteringPointsProcessor(double min_range, double max_range,
+                                      PointsProcessor* next);
+  static std::unique_ptr<MinMaxRangeFilteringPointsProcessor> FromDictionary(
       common::LuaParameterDictionary* dictionary, PointsProcessor* next);
 
-  ~MinMaxRangeFiteringPointsProcessor() override {}
+  ~MinMaxRangeFilteringPointsProcessor() override {}
 
-  MinMaxRangeFiteringPointsProcessor(
-      const MinMaxRangeFiteringPointsProcessor&) = delete;
-  MinMaxRangeFiteringPointsProcessor& operator=(
-      const MinMaxRangeFiteringPointsProcessor&) = delete;
+  MinMaxRangeFilteringPointsProcessor(
+      const MinMaxRangeFilteringPointsProcessor&) = delete;
+  MinMaxRangeFilteringPointsProcessor& operator=(
+      const MinMaxRangeFilteringPointsProcessor&) = delete;
 
   void Process(std::unique_ptr<PointsBatch> batch) override;
   FlushResult Flush() override;

--- a/cartographer/io/points_processor_pipeline_builder.cc
+++ b/cartographer/io/points_processor_pipeline_builder.cc
@@ -83,7 +83,7 @@ void RegisterBuiltInPointsProcessors(
   RegisterPlainPointsProcessor<CountingPointsProcessor>(builder);
   RegisterPlainPointsProcessor<FixedRatioSamplingPointsProcessor>(builder);
   RegisterPlainPointsProcessor<FrameIdFilteringPointsProcessor>(builder);
-  RegisterPlainPointsProcessor<MinMaxRangeFiteringPointsProcessor>(builder);
+  RegisterPlainPointsProcessor<MinMaxRangeFilteringPointsProcessor>(builder);
   RegisterPlainPointsProcessor<OutlierRemovingPointsProcessor>(builder);
   RegisterPlainPointsProcessor<ColoringPointsProcessor>(builder);
   RegisterPlainPointsProcessor<IntensityToColorPointsProcessor>(builder);

--- a/cartographer/io/serialization_format_migration_test.cc
+++ b/cartographer/io/serialization_format_migration_test.cc
@@ -150,7 +150,7 @@ TEST_F(MigrationTest, MigrationAddsHeaderAsFirstMessage) {
 
   mapping::proto::SerializationHeader header;
   EXPECT_TRUE(TextFormat::ParseFromString(output_messages_[0], &header));
-  EXPECT_THAT(header.format_version(), Eq(1));
+  EXPECT_THAT(header.format_version(), Eq(1u));
 }
 
 TEST_F(MigrationTest, MigrationWithGridMigrationAddsHeaderAsFirstMessage) {
@@ -165,7 +165,7 @@ TEST_F(MigrationTest, MigrationWithGridMigrationAddsHeaderAsFirstMessage) {
   mapping::proto::SerializationHeader header;
   EXPECT_TRUE(TextFormat::ParseFromString(
       output_messages_after_migrating_grid_[0], &header));
-  EXPECT_THAT(header.format_version(), Eq(1));
+  EXPECT_THAT(header.format_version(), Eq(1u));
 }
 
 TEST_F(MigrationTest, SerializedDataOrderIsCorrect) {


### PR DESCRIPTION
Fixes the typo mentioned in #1637.
Also improves naming and ran clang-format.

Changed an integer literal to unsigned to
fix a compiler warning.