### PR TITLE
Introduce CARTOGRAPHER_CONFIG_DIR for relocatable

### DIFF
--- a/cartographer/common/configuration_file_resolver.cc
+++ b/cartographer/common/configuration_file_resolver.cc
@@ -19,6 +19,7 @@
 #include <fstream>
 #include <iostream>
 #include <streambuf>
+#include <cstdlib>
 
 #include "cartographer/common/config.h"
 #include "glog/logging.h"
@@ -29,7 +30,11 @@ namespace common {
 ConfigurationFileResolver::ConfigurationFileResolver(
     const std::vector<std::string>& configuration_files_directories)
     : configuration_files_directories_(configuration_files_directories) {
-  configuration_files_directories_.push_back(kConfigurationFilesDirectory);
+  if(const char* config_dir = std::getenv("CARTOGRAPHER_CONFIG_DIR")) {
+    configuration_files_directories_.push_back(config_dir);
+  } else {
+    configuration_files_directories_.push_back(kConfigurationFilesDirectory);
+  }
 }
 
 std::string ConfigurationFileResolver::GetFullPathOrDie(


### PR DESCRIPTION
This pull request is motivated by that on Windows, usually the binaries will be redistributed to a different location than where it was built. However, the current setting of cartographer will look for a [location](https://github.com/cartographer-project/cartographer/blob/2bd987ffb40e2d6667682c5c96432173f371094f/cartographer/common/config.h.cmake#L24) determined at compiled time.

This change is to introduce an environment variable, `CARTOGRAPHER_CONFIG_DIR`, which gives the developers an option to override the default setting, so that makes the binaries more relocatable.