### PR TITLE
Minor fixes for Cartographer from ROS

### DIFF
--- a/cmake/modules/FindGMock.cmake
+++ b/cmake/modules/FindGMock.cmake
@@ -77,6 +77,7 @@ if(NOT GMock_FOUND)
           EXCLUDE_FROM_ALL)
       endif()
       set(GMOCK_LIBRARIES gmock_main)
+      set(GMOCK_INCLUDE_DIRS ${GMOCK_SRC_DIR}/include)
     endif()
   endif()
 

--- a/package.xml
+++ b/package.xml
@@ -38,6 +38,7 @@
 
   <build_depend>git</build_depend>
   <build_depend>google-mock</build_depend>
+  <build_depend>gtest</build_depend>
   <build_depend>python3-sphinx</build_depend>
 
   <depend>libboost-iostreams-dev</depend>

--- a/package.xml
+++ b/package.xml
@@ -40,7 +40,7 @@
   <build_depend>google-mock</build_depend>
   <build_depend>python3-sphinx</build_depend>
 
-  <depend>boost</depend>
+  <depend>libboost-iostreams-dev</depend>
   <depend>eigen</depend>
   <depend>libcairo2-dev</depend>
   <depend>libceres-dev</depend>


### PR DESCRIPTION
This PR is a "port" of the Cartographer code to ROS 2. I put the words port in quotes because the port doesn't require very much; it is mostly changes to compile on Ubuntu 20.04, plus some changes to the package.xml to make it a pure cmake package rather than a catkin one.

As-is, this PR doesn't apply to master. That's because this "port" was originally done against the 1.0.0 tag of this repository. However, given the rather simple nature of this PR, it should be pretty easy to move forward.

I'm opening this PR as a starting point for the discussion on how to move this code into the upstream. Some steps that seem obvious to me:

* ~~Update this to apply against master.~~ This is now done.
* ~~Create a ros2 branch for this to target~~ We decided to try to merge this all into master.

Some steps that are less obvious, and/or need discussion:

* ~~Do we want to try to support ROS 1 and ROS 2 on the same branch? It might be possible here, but I'm not sure.~~  We decided we do.
* Is the cartographer project willing to take over maintenance of this branch and release it into newer ROS 2 versions as they come along?

Finally, I'll note that I don't have too much of time to devote to this. I'm doing this on discretionary time, so while I'm glad to do some simple work here, I won't have the time to do any major refactoring.

Comments, questions, thoughts all welcome!

This was originally PR #1701, but I had to close that one and move it to a new source branch.  Below are comments from that PR.

---

@wohe said:

@clalancette I opened #1704 for the remaining focal related fixes. Some of the changes in this PR have already been fixed. I'll send a PR which adds focal to CI later.

Since this is the library without a dependency on ROS it should be possible to have one version for both ROS 1 and 2. The only ROS related file is the package.xml which to my understanding allows configuring dependencies differently based on the ROS version. Should we do this? Can you have a look? I dont't think anything would speak against merging a PR which just fixes up the package.xml for ROS 2 support.

---

@clalancette said:


>    @clalancette I opened #1704 for the remaining focal related fixes. Some of the changes in this PR have already been fixed. I'll send a PR which adds focal to CI later.

Great, thanks!

>    Since this is the library without a dependency on ROS it should be possible to have one version for both ROS 1 and 2. The only ROS related file is the package.xml which to my understanding allows configuring dependencies differently based on the ROS version. Should we do this? Can you have a look? I dont't think anything would speak against merging a PR which just fixes up the package.xml for ROS 2 support.

Yep, in theory we should be able to do that. I'm going to rebase this on top of master, and then see if I can get that working.