### PR TITLE
Deactivate memory-critical histogram backwards compatibility.

### DIFF
--- a/cartographer/cloud/internal/client_server_test.cc
+++ b/cartographer/cloud/internal/client_server_test.cc
@@ -55,7 +55,7 @@ constexpr double kDuration = 4.;         // Seconds.
 constexpr double kTimeStep = 0.1;        // Seconds.
 constexpr double kTravelDistance = 1.2;  // Meters.
 
-constexpr char kSerializationHeaderProtoString[] = "format_version: 1";
+constexpr char kSerializationHeaderProtoString[] = "format_version: 2";
 constexpr char kPoseGraphProtoString[] = R"(pose_graph {
       trajectory: {
         trajectory_id: 0

--- a/cartographer/mapping/map_builder.cc
+++ b/cartographer/mapping/map_builder.cc
@@ -285,8 +285,12 @@ std::map<int, int> MapBuilder::LoadState(
                                  true);
   }
 
-  MapById<SubmapId, mapping::proto::Submap> submap_id_to_submap;
-  MapById<NodeId, mapping::proto::Node> node_id_to_node;
+  CHECK_NE(deserializer.header().format_version(),
+           io::kFormatVersionWithoutSubmapHistograms)
+      << "The pbstream file contains submaps without rotational histograms. "
+         "This can be converted, but the conversion was removed here due to "
+         "memory concerns.";
+
   SerializedData proto;
   while (deserializer.ReadNextSerializedData(&proto)) {
     switch (proto.data_case()) {
@@ -303,10 +307,11 @@ std::map<int, int> MapBuilder::LoadState(
         proto.mutable_submap()->mutable_submap_id()->set_trajectory_id(
             trajectory_remapping.at(
                 proto.submap().submap_id().trajectory_id()));
-        submap_id_to_submap.Insert(
+        const auto submap_id =
             SubmapId{proto.submap().submap_id().trajectory_id(),
-                     proto.submap().submap_id().submap_index()},
-            proto.submap());
+                     proto.submap().submap_id().submap_index()};
+        pose_graph_->AddSubmapFromProto(submap_poses.at(submap_id),
+                                        proto.submap());
         break;
       }
       case SerializedData::kNode: {
@@ -316,7 +321,6 @@ std::map<int, int> MapBuilder::LoadState(
                              proto.node().node_id().node_index());
         const transform::Rigid3d& node_pose = node_poses.at(node_id);
         pose_graph_->AddNodeFromProto(node_pose, proto.node());
-        node_id_to_node.Insert(node_id, proto.node());
         break;
       }
       case SerializedData::kTrajectoryData: {
@@ -359,20 +363,6 @@ std::map<int, int> MapBuilder::LoadState(
         LOG(WARNING) << "Skipping unknown message type in stream: "
                      << proto.GetTypeName();
     }
-  }
-
-  // TODO(schwoere): Remove backwards compatibility once the pbstream format
-  // version 2 is established.
-  if (deserializer.header().format_version() ==
-      io::kFormatVersionWithoutSubmapHistograms) {
-    submap_id_to_submap =
-        cartographer::io::MigrateSubmapFormatVersion1ToVersion2(
-            submap_id_to_submap, node_id_to_node, pose_graph_proto);
-  }
-
-  for (const auto& submap_id_submap : submap_id_to_submap) {
-    pose_graph_->AddSubmapFromProto(submap_poses.at(submap_id_submap.id),
-                                    submap_id_submap.data);
   }
 
   if (load_frozen_state) {

--- a/cartographer/mapping/map_builder.cc
+++ b/cartographer/mapping/map_builder.cc
@@ -285,11 +285,13 @@ std::map<int, int> MapBuilder::LoadState(
                                  true);
   }
 
-  CHECK_NE(deserializer.header().format_version(),
-           io::kFormatVersionWithoutSubmapHistograms)
-      << "The pbstream file contains submaps without rotational histograms. "
-         "This can be converted, but the conversion was removed here due to "
-         "memory concerns.";
+  if (options_.use_trajectory_builder_3d()) {
+    CHECK_NE(deserializer.header().format_version(),
+             io::kFormatVersionWithoutSubmapHistograms)
+        << "The pbstream file contains submaps without rotational histograms. "
+           "This can be converted with the 'pbstream migrate' tool, see the "
+           "Cartographer documentation for details. ";
+  }
 
   SerializedData proto;
   while (deserializer.ReadNextSerializedData(&proto)) {

--- a/cartographer/mapping/map_builder.cc
+++ b/cartographer/mapping/map_builder.cc
@@ -309,9 +309,8 @@ std::map<int, int> MapBuilder::LoadState(
         proto.mutable_submap()->mutable_submap_id()->set_trajectory_id(
             trajectory_remapping.at(
                 proto.submap().submap_id().trajectory_id()));
-        const auto submap_id =
-            SubmapId{proto.submap().submap_id().trajectory_id(),
-                     proto.submap().submap_id().submap_index()};
+        const SubmapId submap_id(proto.submap().submap_id().trajectory_id(),
+                                 proto.submap().submap_id().submap_index());
         pose_graph_->AddSubmapFromProto(submap_poses.at(submap_id),
                                         proto.submap());
         break;


### PR DESCRIPTION
It's essentially leading to buffering all submaps twice, which
is a high (~2x) peak in memory consumption during deserialization.

Don't convert anymore since this affects _all_ pbstreams and not only
the (probably few) old pbstreams that require the conversion.