### PR TITLE
Change pbstream migrate to support new submap format.

### DIFF
--- a/cartographer/io/internal/pbstream_migrate.cc
+++ b/cartographer/io/internal/pbstream_migrate.cc
@@ -21,19 +21,18 @@
 #include "gflags/gflags.h"
 #include "glog/logging.h"
 
-DEFINE_bool(migrate_grid_format, false,
-            "Set if the submap data of the input pbstream uses the old "
-            "probability grid format.");
+DEFINE_bool(include_unfinished_submaps, true,
+            "Whether to write to include unfinished submaps in the output.");
 
 namespace cartographer {
 namespace io {
 
 int pbstream_migrate(int argc, char** argv) {
   std::stringstream ss;
-  ss << "\n\nTool for migrating files that use the serialization output of "
-        "Cartographer 0.3, to the new serialization format, which includes a "
-        "header (Version 1). You may need to specify the '--migrate_grid_format"
-        " flag if the input file contains submaps with the legacy grid format."
+  ss << "\n\nTool for migrating files that use submaps without histograms "
+        "to the new submap format, which includes a histogram. You can "
+        "set --include_unfinished_submaps to false if you want to exclude "
+        "unfinished submaps in the output."
      << "\nUsage: " << argv[0] << " " << argv[1]
      << " <input_filename> <output_filename> [flags]";
   google::SetUsageMessage(ss.str());
@@ -44,10 +43,10 @@ int pbstream_migrate(int argc, char** argv) {
   }
   cartographer::io::ProtoStreamReader input(argv[2]);
   cartographer::io::ProtoStreamWriter output(argv[3]);
-  LOG(INFO) << "Migrating old serialization format in \"" << argv[2]
-            << "\" to new serialization format in \"" << argv[3] << "\"";
-  cartographer::io::MigrateStreamFormatToVersion1(&input, &output,
-                                                  FLAGS_migrate_grid_format);
+  LOG(INFO) << "Migrating serialization format 1 in \"" << argv[2]
+            << "\" to serialization format 2 in \"" << argv[3] << "\"";
+  cartographer::io::MigrateStreamVersion1ToVersion2(
+      &input, &output, FLAGS_include_unfinished_submaps);
   CHECK(output.Close()) << "Could not write migrated pbstream file to: "
                         << argv[3];
 

--- a/cartographer/io/internal/pbstream_migrate.cc
+++ b/cartographer/io/internal/pbstream_migrate.cc
@@ -22,7 +22,7 @@
 #include "glog/logging.h"
 
 DEFINE_bool(include_unfinished_submaps, true,
-            "Whether to write to include unfinished submaps in the output.");
+            "Whether to include unfinished submaps in the output.");
 
 namespace cartographer {
 namespace io {

--- a/cartographer/io/pbstream_main.cc
+++ b/cartographer/io/pbstream_main.cc
@@ -30,12 +30,12 @@ int main(int argc, char** argv) {
       "Swiss Army knife for pbstreams.\n\n"
       "Currently supported subcommands are:\n"
       "\tinfo    - Prints summary of pbstream.\n"
-      "\tmigrate - Migrates old pbstream (w/o header) to new pbstream format.";
+      "\tmigrate - Migrates pbstream to the new submap format.";
   google::ParseCommandLineFlags(&argc, &argv, true);
 
   if (argc < 2) {
     google::SetUsageMessage(usage_message);
-    google::ShowUsageWithFlagsRestrict(argv[0], "pbstream_info_main");
+    google::ShowUsageWithFlagsRestrict(argv[0], "pbstream_main");
     return EXIT_FAILURE;
   } else if (std::string(argv[1]) == "info") {
     return ::cartographer::io::pbstream_info(argc, argv);
@@ -44,7 +44,7 @@ int main(int argc, char** argv) {
   } else {
     LOG(INFO) << "Unknown subtool: \"" << argv[1];
     google::SetUsageMessage(usage_message);
-    google::ShowUsageWithFlagsRestrict(argv[0], "pbstream_info_main");
+    google::ShowUsageWithFlagsRestrict(argv[0], "pbstream_main");
     return EXIT_FAILURE;
   }
 }

--- a/cartographer/io/serialization_format_migration.cc
+++ b/cartographer/io/serialization_format_migration.cc
@@ -128,14 +128,12 @@ void MigrateStreamVersion1ToVersion2(
   while (deserializer.ReadNextSerializedData(&proto)) {
     switch (proto.data_case()) {
       case SerializedData::kPoseGraph:
-        LOG(ERROR) << "Found multiple serialized `PoseGraph`. Serialized "
+        LOG(FATAL) << "Found multiple serialized `PoseGraph`. Serialized "
                       "stream likely corrupt!.";
-        break;
       case SerializedData::kAllTrajectoryBuilderOptions:
-        LOG(ERROR) << "Found multiple serialized "
+        LOG(FATAL) << "Found multiple serialized "
                       "`AllTrajectoryBuilderOptions`. Serialized stream likely "
                       "corrupt!.";
-        break;
       case SerializedData::kSubmap: {
         CHECK(proto.submap().has_submap_3d())
             << "Converting to the new submap format only makes sense for 3D.";

--- a/cartographer/io/serialization_format_migration.h
+++ b/cartographer/io/serialization_format_migration.h
@@ -24,14 +24,13 @@
 namespace cartographer {
 namespace io {
 
-// This helper function, migrates the input stream, which is supposed to match
-// to the "old" stream format order (PoseGraph, AllTrajectoryBuilderOptions,
-// SerializedData*) to the version 1 stream format (SerializationHeader,
-// SerializedData*).
-void MigrateStreamFormatToVersion1(
+// This helper function migrates the input stream, which is supposed
+// to contain submaps without histograms (stream format version 1) to
+// an output stream containing submaps with histograms (version 2).
+void MigrateStreamVersion1ToVersion2(
     cartographer::io::ProtoStreamReaderInterface* const input,
     cartographer::io::ProtoStreamWriterInterface* const output,
-    bool migrate_grid_format);
+    bool include_unfinished_submaps);
 
 mapping::MapById<mapping::SubmapId, mapping::proto::Submap>
 MigrateSubmapFormatVersion1ToVersion2(

--- a/cartographer/io/serialization_format_migration_test.cc
+++ b/cartographer/io/serialization_format_migration_test.cc
@@ -21,7 +21,6 @@
 
 #include "cartographer/io/internal/in_memory_proto_stream.h"
 #include "cartographer/mapping/internal/testing/test_helpers.h"
-#include "cartographer/mapping/proto/internal/legacy_serialized_data.pb.h"
 #include "cartographer/mapping/proto/pose_graph.pb.h"
 #include "cartographer/mapping/proto/serialization.pb.h"
 #include "cartographer/mapping/proto/trajectory_builder_options.pb.h"
@@ -34,74 +33,6 @@
 namespace cartographer {
 namespace io {
 namespace {
-
-using ::google::protobuf::TextFormat;
-using ::testing::Eq;
-using ::testing::SizeIs;
-
-class MigrationTest : public ::testing::Test {
- private:
-  template <class LegacySerializedDataType>
-  void AddLegacyDataToReader(InMemoryProtoStreamReader& reader) {
-    mapping::proto::PoseGraph pose_graph;
-    mapping::proto::AllTrajectoryBuilderOptions all_options;
-    LegacySerializedDataType submap;
-    submap.mutable_submap();
-    LegacySerializedDataType node;
-    node.mutable_node();
-    LegacySerializedDataType imu_data;
-    imu_data.mutable_imu_data();
-    LegacySerializedDataType odometry_data;
-    odometry_data.mutable_odometry_data();
-    LegacySerializedDataType fixed_frame_pose;
-    fixed_frame_pose.mutable_fixed_frame_pose_data();
-    LegacySerializedDataType trajectory_data;
-    trajectory_data.mutable_trajectory_data();
-    LegacySerializedDataType landmark_data;
-    landmark_data.mutable_landmark_data();
-
-    reader.AddProto(pose_graph);
-    reader.AddProto(all_options);
-    reader.AddProto(submap);
-    reader.AddProto(node);
-    reader.AddProto(imu_data);
-    reader.AddProto(odometry_data);
-    reader.AddProto(fixed_frame_pose);
-    reader.AddProto(trajectory_data);
-    reader.AddProto(landmark_data);
-  }
-
- protected:
-  void SetUp() override {
-    AddLegacyDataToReader<mapping::proto::LegacySerializedData>(reader_);
-    AddLegacyDataToReader<mapping::proto::LegacySerializedDataLegacySubmap>(
-        reader_for_migrating_grid_);
-
-    writer_.reset(new ForwardingProtoStreamWriter(
-        [this](const google::protobuf::Message* proto) -> bool {
-          std::string msg_string;
-          TextFormat::PrintToString(*proto, &msg_string);
-          this->output_messages_.push_back(msg_string);
-          return true;
-        }));
-    writer_for_migrating_grid_.reset(new ForwardingProtoStreamWriter(
-        [this](const google::protobuf::Message* proto) -> bool {
-          std::string msg_string;
-          TextFormat::PrintToString(*proto, &msg_string);
-          this->output_messages_after_migrating_grid_.push_back(msg_string);
-          return true;
-        }));
-  }
-
-  InMemoryProtoStreamReader reader_;
-  InMemoryProtoStreamReader reader_for_migrating_grid_;
-  std::unique_ptr<ForwardingProtoStreamWriter> writer_;
-  std::unique_ptr<ForwardingProtoStreamWriter> writer_for_migrating_grid_;
-  std::vector<std::string> output_messages_;
-  std::vector<std::string> output_messages_after_migrating_grid_;
-
-  static constexpr int kNumOriginalMessages = 9;
-};
 
 class SubmapHistogramMigrationTest : public ::testing::Test {
  protected:
@@ -140,81 +71,6 @@ class SubmapHistogramMigrationTest : public ::testing::Test {
   mapping::proto::Submap submap_;
   mapping::proto::Node node_;
 };
-
-TEST_F(MigrationTest, MigrationAddsHeaderAsFirstMessage) {
-  MigrateStreamFormatToVersion1(&reader_, writer_.get(),
-                                false /* migrate_grid_format */);
-  // We expect one message more than the original number of messages, because of
-  // the added header.
-  EXPECT_THAT(output_messages_, SizeIs(kNumOriginalMessages + 1));
-
-  mapping::proto::SerializationHeader header;
-  EXPECT_TRUE(TextFormat::ParseFromString(output_messages_[0], &header));
-  EXPECT_THAT(header.format_version(), Eq(1u));
-}
-
-TEST_F(MigrationTest, MigrationWithGridMigrationAddsHeaderAsFirstMessage) {
-  MigrateStreamFormatToVersion1(&reader_for_migrating_grid_,
-                                writer_for_migrating_grid_.get(),
-                                true /* migrate_grid_format */);
-  // We expect one message more than the original number of messages, because of
-  // the added header.
-  EXPECT_THAT(output_messages_after_migrating_grid_,
-              SizeIs(kNumOriginalMessages + 1));
-
-  mapping::proto::SerializationHeader header;
-  EXPECT_TRUE(TextFormat::ParseFromString(
-      output_messages_after_migrating_grid_[0], &header));
-  EXPECT_THAT(header.format_version(), Eq(1u));
-}
-
-TEST_F(MigrationTest, SerializedDataOrderIsCorrect) {
-  MigrateStreamFormatToVersion1(&reader_, writer_.get(),
-                                false /* migrate_grid_format */);
-  EXPECT_THAT(output_messages_, SizeIs(kNumOriginalMessages + 1));
-
-  std::vector<mapping::proto::SerializedData> serialized(
-      output_messages_.size() - 1);
-  for (size_t i = 1; i < output_messages_.size(); ++i) {
-    EXPECT_TRUE(
-        TextFormat::ParseFromString(output_messages_[i], &serialized[i - 1]));
-  }
-
-  EXPECT_TRUE(serialized[0].has_pose_graph());
-  EXPECT_TRUE(serialized[1].has_all_trajectory_builder_options());
-  EXPECT_TRUE(serialized[2].has_submap());
-  EXPECT_TRUE(serialized[3].has_node());
-  EXPECT_TRUE(serialized[4].has_trajectory_data());
-  EXPECT_TRUE(serialized[5].has_imu_data());
-  EXPECT_TRUE(serialized[6].has_odometry_data());
-  EXPECT_TRUE(serialized[7].has_fixed_frame_pose_data());
-  EXPECT_TRUE(serialized[8].has_landmark_data());
-}
-
-TEST_F(MigrationTest, SerializedDataOrderAfterGridMigrationIsCorrect) {
-  MigrateStreamFormatToVersion1(&reader_for_migrating_grid_,
-                                writer_for_migrating_grid_.get(),
-                                true /* migrate_grid_format */);
-  EXPECT_THAT(output_messages_after_migrating_grid_,
-              SizeIs(kNumOriginalMessages + 1));
-
-  std::vector<mapping::proto::SerializedData> serialized(
-      output_messages_after_migrating_grid_.size() - 1);
-  for (size_t i = 1; i < output_messages_after_migrating_grid_.size(); ++i) {
-    EXPECT_TRUE(TextFormat::ParseFromString(
-        output_messages_after_migrating_grid_[i], &serialized[i - 1]));
-  }
-
-  EXPECT_TRUE(serialized[0].has_pose_graph());
-  EXPECT_TRUE(serialized[1].has_all_trajectory_builder_options());
-  EXPECT_TRUE(serialized[2].has_submap());
-  EXPECT_TRUE(serialized[3].has_node());
-  EXPECT_TRUE(serialized[4].has_trajectory_data());
-  EXPECT_TRUE(serialized[5].has_imu_data());
-  EXPECT_TRUE(serialized[6].has_odometry_data());
-  EXPECT_TRUE(serialized[7].has_fixed_frame_pose_data());
-  EXPECT_TRUE(serialized[8].has_landmark_data());
-}
 
 TEST_F(SubmapHistogramMigrationTest,
        SubmapHistogramGenerationFromTrajectoryNodes) {

--- a/docs/source/pbstream_migration.rst
+++ b/docs/source/pbstream_migration.rst
@@ -16,22 +16,30 @@
 Migration tool for pbstream files
 =================================
 
-With the update of the pbstream serialization format as discussed in
-`RFC-0021`_, previously serialized pbstream files are not loadable in
-Cartographer 1.0 anymore.
-
-In order to enable users to reuse previously generated pbstream files, we
-provide a migration tool which converts pbstreams from Cartographer 0.3 to the
-new serialization format used in Cartographer 1.0.
+The pbstream serialization format for 3D has changed to include additional
+data (histograms) in each submap. Code to load old data by migrating
+on-the-fly will be removed soon. Once this happened, users who wish to
+migrate old pbstream files can use a migration tool.
 
 The tool is shipped as part of Cartographer's pbstream tool (`source`_) and once
 built can be invoked as follows:::
 
   cartographer_pbstream migrate old.pbstream new.pbstream
 
-The tool assumes that the first pbstream provided as commandline argument,
-follows the serialization format of Cartographer 0.3. The resulting
-1.0 pbstream will be saved to the second commandline argument location.
+The tool assumes 3D data in the old submap format as input and converts it
+to the currently used format version.
+
+Migrating pre-1.0 pbstream files
+================================
+
+With the update of the pbstream serialization format as discussed in
+`RFC-0021`_, previously serialized pbstream files are not loadable in
+Cartographer 1.0 anymore.
+
+In order to enable users to reuse previously generated pbstream files,
+migration using an older version of the migration tool is necessary.
+The current tool does not support this migration anymore. Please use
+the version at Git SHA 6c889490e245cc5d9da15023249c6fc7119def3f.
 
 .. _RFC-0021: https://github.com/cartographer-project/rfcs/blob/master/text/0021-serialization-format.md
 .. _source: https://github.com/cartographer-project/cartographer/blob/master/cartographer/io/pbstream_main.cc


### PR DESCRIPTION
This changes the migration support to:
1. Remove migration from old files from before version 1.0.
   If this is still needed by someone, they can use the tool
   as it was before this change.
2. Adds migration of maps without submap histograms. These
   were so far migrated on-the-fly, but #1710 aims to remove
   this.

See also #1709.

This was tested by converting a serialized 3D map and verifying
it can still be used for localization. The file changed a little
bit, but it seems to be good enough.

Signed-off-by: Wolfgang Hess <whess@lyft.com>