### PR TITLE
Add IntensityHybridGrid.

### DIFF
--- a/cartographer/mapping/3d/hybrid_grid.h
+++ b/cartographer/mapping/3d/hybrid_grid.h
@@ -544,6 +544,32 @@ class HybridGrid : public HybridGridBase<uint16> {
   std::vector<ValueType*> update_indices_;
 };
 
+struct AverageIntensityData {
+  float sum = 0.f;
+  int count = 0;
+};
+
+class IntensityHybridGrid : public HybridGridBase<AverageIntensityData> {
+ public:
+  explicit IntensityHybridGrid(const float resolution)
+      : HybridGridBase<AverageIntensityData>(resolution) {}
+
+  void AddIntensity(const Eigen::Array3i& index, const float intensity) {
+    AverageIntensityData* const cell = mutable_value(index);
+    cell->count += 1;
+    cell->sum += intensity;
+  }
+
+  float GetIntensity(const Eigen::Array3i& index) const {
+    const AverageIntensityData& cell = value(index);
+    if (cell.count == 0) {
+      return 0.f;
+    } else {
+      return cell.sum / cell.count;
+    }
+  }
+};
+
 }  // namespace mapping
 }  // namespace cartographer
 

--- a/cartographer/mapping/3d/hybrid_grid_test.cc
+++ b/cartographer/mapping/3d/hybrid_grid_test.cc
@@ -84,6 +84,23 @@ TEST(HybridGridTest, GetProbability) {
   }
 }
 
+TEST(HybridGridTest, GetIntensity) {
+  IntensityHybridGrid hybrid_grid(1.f);
+  const Eigen::Array3i cell_index =
+      hybrid_grid.GetCellIndex(Eigen::Vector3f(0.f, 1.f, 1.f));
+  const float intensity = 58.0f;
+
+  EXPECT_NEAR(hybrid_grid.GetIntensity(cell_index), 0.0f, 1e-9);
+  hybrid_grid.AddIntensity(cell_index, intensity);
+  EXPECT_NEAR(hybrid_grid.GetIntensity(cell_index), intensity, 1e-9);
+  for (const Eigen::Array3i& index :
+       {hybrid_grid.GetCellIndex(Eigen::Vector3f(0.f, 2.f, 1.f)),
+        hybrid_grid.GetCellIndex(Eigen::Vector3f(1.f, 1.f, 1.f)),
+        hybrid_grid.GetCellIndex(Eigen::Vector3f(1.f, 2.f, 1.f))}) {
+    EXPECT_NEAR(hybrid_grid.GetIntensity(index), 0.0f, 1e-9);
+  }
+}
+
 MATCHER_P(AllCwiseEqual, index, "") { return (arg == index).all(); }
 
 TEST(HybridGridTest, GetCellIndex) {

--- a/cartographer/mapping/internal/3d/scan_matching/interpolated_grid_test.cc
+++ b/cartographer/mapping/internal/3d/scan_matching/interpolated_grid_test.cc
@@ -44,7 +44,7 @@ class InterpolatedGridTest : public ::testing::Test {
   }
 
   HybridGrid hybrid_grid_;
-  InterpolatedGrid interpolated_grid_;
+  InterpolatedProbabilityGrid interpolated_grid_;
 };
 
 TEST_F(InterpolatedGridTest, InterpolatesGridPoints) {
@@ -52,7 +52,7 @@ TEST_F(InterpolatedGridTest, InterpolatesGridPoints) {
     for (double y = 1.; y < 5.; y += hybrid_grid_.resolution()) {
       for (double x = -8.; x < -2.; x += hybrid_grid_.resolution()) {
         EXPECT_NEAR(GetHybridGridProbability(x, y, z),
-                    interpolated_grid_.GetProbability(x, y, z), 1e-6);
+                    interpolated_grid_.GetInterpolatedValue(x, y, z), 1e-6);
       }
     }
   }
@@ -73,10 +73,11 @@ TEST_F(InterpolatedGridTest, MonotonicBehaviorBetweenGridPointsInX) {
         for (double sample = kSampleStep;
              sample < hybrid_grid_.resolution() - 2 * kSampleStep;
              sample += kSampleStep) {
-          EXPECT_LT(0., grid_difference * (interpolated_grid_.GetProbability(
-                                               x + sample + kSampleStep, y, z) -
-                                           interpolated_grid_.GetProbability(
-                                               x + sample, y, z)));
+          EXPECT_LT(0.,
+                    grid_difference * (interpolated_grid_.GetInterpolatedValue(
+                                           x + sample + kSampleStep, y, z) -
+                                       interpolated_grid_.GetInterpolatedValue(
+                                           x + sample, y, z)));
         }
       }
     }

--- a/cartographer/mapping/internal/3d/scan_matching/occupied_space_cost_function_3d.h
+++ b/cartographer/mapping/internal/3d/scan_matching/occupied_space_cost_function_3d.h
@@ -73,7 +73,7 @@ class OccupiedSpaceCostFunction3D {
       const Eigen::Matrix<T, 3, 1> world =
           transform * point_cloud_[i].position.cast<T>();
       const T probability =
-          interpolated_grid_.GetProbability(world[0], world[1], world[2]);
+          interpolated_grid_.GetInterpolatedValue(world[0], world[1], world[2]);
       residual[i] = scaling_factor_ * (1. - probability);
     }
     return true;
@@ -81,7 +81,7 @@ class OccupiedSpaceCostFunction3D {
 
   const double scaling_factor_;
   const sensor::PointCloud& point_cloud_;
-  const InterpolatedGrid interpolated_grid_;
+  const InterpolatedProbabilityGrid interpolated_grid_;
 };
 
 }  // namespace scan_matching


### PR DESCRIPTION
Adds a new structure IntensityHybridGrid, similar to HybridGrid
but which stores intensities instead of probabilities.
InterpolatedGrid is adapted to handle both types of HybridGrids.

Signed-off-by: Wolfgang Hess <whess@lyft.com>