### PR TITLE
Updated the ROS on Windows feed URL

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ jobs:
   timeoutInMinutes: 360
   steps:
   - script: |
-      choco sources add -n=roswin -s https://roswin.azurewebsites.net/api/v2/ --priority 1
+      choco sources add -n=roswin -s https://aka.ms/ros/public --priority 1
       rem Azure VM runs out of space on C:, so use D: for ros and rosdeps
       mkdir D:\opt && mklink /J C:\opt D:\opt
       choco upgrade %ROS_METAPACKAGE% -y


### PR DESCRIPTION
Hi! I am from `ROS on Windows` team and we are currently migrating the feed URL. [Link](https://discourse.ros.org/t/reminder-https-aka-ms-ros-public-the-new-chocolatey-feed-url-for-ros-on-windows/16098).

This change is to update the URL and let me know if any additional questions! Thanks!