### PR TITLE
Delete submap scan matchers that are unconstrained after trimming.

### DIFF
--- a/cartographer/mapping/internal/2d/pose_graph_2d.cc
+++ b/cartographer/mapping/internal/2d/pose_graph_2d.cc
@@ -1264,6 +1264,9 @@ void PoseGraph2D::TrimmingHandle::TrimSubmap(const SubmapId& submap_id) {
       }
     }
     // Delete scan matchers of the submaps that lost all constraints.
+    // TODO(wohe): An improvement to this implementation would be to add the
+    // caching logic at the constraint builder which could keep around only
+    // recently used scan matchers.
     for (const SubmapId& submap_id : other_submap_ids_losing_constraints) {
       parent_->constraint_builder_.DeleteScanMatcher(submap_id);
     }

--- a/cartographer/mapping/internal/2d/pose_graph_2d.cc
+++ b/cartographer/mapping/internal/2d/pose_graph_2d.cc
@@ -1238,31 +1238,33 @@ void PoseGraph2D::TrimmingHandle::TrimSubmap(const SubmapId& submap_id) {
     parent_->data_.constraints = std::move(constraints);
   }
   // Remove all 'data_.constraints' related to 'nodes_to_remove'.
+  // If the removal lets other submaps lose all their inter-submap constraints,
+  // delete their corresponding constraint submap matchers to save memory.
   {
     std::vector<Constraint> constraints;
-    std::set<SubmapId> unconstrained_submap_ids;
+    std::set<SubmapId> other_submap_ids_losing_constraints;
     for (const Constraint& constraint : parent_->data_.constraints) {
       if (nodes_to_remove.count(constraint.node_id) == 0) {
         constraints.push_back(constraint);
       } else {
         // A constraint to another submap will be removed, mark it as affected.
-        unconstrained_submap_ids.insert(constraint.submap_id);
+        other_submap_ids_losing_constraints.insert(constraint.submap_id);
       }
     }
     parent_->data_.constraints = std::move(constraints);
-    // Go through the changed constraints and finalize the list of submap IDs
-    // that lost constraints and now have zero inter-submap constraints.
+    // Go through the remaining constraints to ensure we only delete scan
+    // matchers of other submaps that have no inter-submap constraints left.
     for (const Constraint& constraint : parent_->data_.constraints) {
       if (constraint.tag == Constraint::Tag::INTRA_SUBMAP) {
         continue;
-      } else if (unconstrained_submap_ids.count(constraint.submap_id)) {
-        // False positive - this submap is still inter-submap-constrained with
-        // some node that is not from the submap that will be trimmed.
-        unconstrained_submap_ids.erase(constraint.submap_id);
+      } else if (other_submap_ids_losing_constraints.count(
+                     constraint.submap_id)) {
+        // This submap still has inter-submap constraints - ignore it.
+        other_submap_ids_losing_constraints.erase(constraint.submap_id);
       }
     }
-    // Delete submap scan matchers of now unconstrained submaps to save memory.
-    for (const SubmapId& submap_id : unconstrained_submap_ids) {
+    // Delete scan matchers of the submaps that lost all constraints.
+    for (const SubmapId& submap_id : other_submap_ids_losing_constraints) {
       parent_->constraint_builder_.DeleteScanMatcher(submap_id);
     }
   }


### PR DESCRIPTION
This improves the memory issue in pure localization mode as
mentioned in issue #1737.

Signed-off-by: Michael Grupp <grupp@magazino.eu>
