### PR TITLE
Depend on libceres-dev in package.xml for ROS.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -41,9 +41,9 @@
   <build_depend>python3-sphinx</build_depend>
 
   <depend>boost</depend>
-  <depend>ceres-solver</depend>
   <depend>eigen</depend>
   <depend>libcairo2-dev</depend>
+  <depend>libceres-dev</depend>
   <depend>libgflags-dev</depend>
   <depend>libgoogle-glog-dev</depend>
   <depend>lua5.2-dev</depend>


### PR DESCRIPTION
This changes cartographer_ros to no longer build
Ceres and instead uses libceres-dev for which a
suitable version is provided by ROS for Kinetic.

Related to #1705.

Signed-off-by: Wolfgang Hess <whess@lyft.com>