### PR TITLE
Don't add IMU data to 2D optimization problem.

### DIFF
--- a/cartographer/mapping/internal/optimization/optimization_problem_2d.cc
+++ b/cartographer/mapping/internal/optimization/optimization_problem_2d.cc
@@ -208,7 +208,7 @@ void OptimizationProblem2D::InsertTrajectoryNode(const NodeId& node_id,
 }
 
 void OptimizationProblem2D::TrimTrajectoryNode(const NodeId& node_id) {
-  imu_data_.Trim(node_data_, node_id);
+  empty_imu_data_.Trim(node_data_, node_id);
   odometry_data_.Trim(node_data_, node_id);
   fixed_frame_pose_data_.Trim(node_data_, node_id);
   node_data_.Trim(node_id);

--- a/cartographer/mapping/internal/optimization/optimization_problem_2d.cc
+++ b/cartographer/mapping/internal/optimization/optimization_problem_2d.cc
@@ -175,7 +175,9 @@ OptimizationProblem2D::~OptimizationProblem2D() {}
 
 void OptimizationProblem2D::AddImuData(const int trajectory_id,
                                        const sensor::ImuData& imu_data) {
-  imu_data_.Append(trajectory_id, imu_data);
+  // TODO(MichaelGrupp): IMU data is currently not used in 2D optimization
+  // and just accumulates memory, so we ignore it for now.
+  // imu_data_.Append(trajectory_id, imu_data);
 }
 
 void OptimizationProblem2D::AddOdometryData(

--- a/cartographer/mapping/internal/optimization/optimization_problem_2d.cc
+++ b/cartographer/mapping/internal/optimization/optimization_problem_2d.cc
@@ -175,9 +175,8 @@ OptimizationProblem2D::~OptimizationProblem2D() {}
 
 void OptimizationProblem2D::AddImuData(const int trajectory_id,
                                        const sensor::ImuData& imu_data) {
-  // TODO(MichaelGrupp): IMU data is currently not used in 2D optimization
-  // and just accumulates memory, so we ignore it for now.
-  // imu_data_.Append(trajectory_id, imu_data);
+  // IMU data is currently not used in 2D optimization, so we ignore this part
+  // of the interface for now.
 }
 
 void OptimizationProblem2D::AddOdometryData(

--- a/cartographer/mapping/internal/optimization/optimization_problem_2d.cc
+++ b/cartographer/mapping/internal/optimization/optimization_problem_2d.cc
@@ -175,8 +175,8 @@ OptimizationProblem2D::~OptimizationProblem2D() {}
 
 void OptimizationProblem2D::AddImuData(const int trajectory_id,
                                        const sensor::ImuData& imu_data) {
-  // IMU data is currently not used in 2D optimization, so we ignore this part
-  // of the interface for now.
+  // IMU data is not used in 2D optimization, so we ignore this part of the
+  // interface.
 }
 
 void OptimizationProblem2D::AddOdometryData(

--- a/cartographer/mapping/internal/optimization/optimization_problem_2d.h
+++ b/cartographer/mapping/internal/optimization/optimization_problem_2d.h
@@ -128,7 +128,6 @@ class OptimizationProblem2D
   MapById<NodeId, NodeSpec2D> node_data_;
   MapById<SubmapId, SubmapSpec2D> submap_data_;
   std::map<std::string, transform::Rigid3d> landmark_data_;
-  // IMU data is not used in 2D optimization currently and will be empty.
   sensor::MapByTime<sensor::ImuData> empty_imu_data_;
   sensor::MapByTime<sensor::OdometryData> odometry_data_;
   sensor::MapByTime<sensor::FixedFramePoseData> fixed_frame_pose_data_;

--- a/cartographer/mapping/internal/optimization/optimization_problem_2d.h
+++ b/cartographer/mapping/internal/optimization/optimization_problem_2d.h
@@ -94,7 +94,7 @@ class OptimizationProblem2D
     return landmark_data_;
   }
   const sensor::MapByTime<sensor::ImuData>& imu_data() const override {
-    return imu_data_;
+    return empty_imu_data_;
   }
   const sensor::MapByTime<sensor::OdometryData>& odometry_data()
       const override {
@@ -128,7 +128,8 @@ class OptimizationProblem2D
   MapById<NodeId, NodeSpec2D> node_data_;
   MapById<SubmapId, SubmapSpec2D> submap_data_;
   std::map<std::string, transform::Rigid3d> landmark_data_;
-  sensor::MapByTime<sensor::ImuData> imu_data_;
+  // IMU data is not used in 2D optimization currently and will be empty.
+  sensor::MapByTime<sensor::ImuData> empty_imu_data_;
   sensor::MapByTime<sensor::OdometryData> odometry_data_;
   sensor::MapByTime<sensor::FixedFramePoseData> fixed_frame_pose_data_;
   std::map<int, PoseGraphInterface::TrajectoryData> trajectory_data_;


### PR DESCRIPTION
It was constantly added regardless of motion filtering. Since it's not
used it can be just ignored. The method still needs to be there to
satisfy the interface.

Signed-off-by: Michael Grupp <grupp@magazino.eu>