### PR TITLE
Constrain gravity to be positive.

### DIFF
--- a/cartographer/mapping/internal/optimization/optimization_problem_3d.cc
+++ b/cartographer/mapping/internal/optimization/optimization_problem_3d.cc
@@ -441,6 +441,9 @@ void OptimizationProblem3D::Solve(
             C_nodes.at(second_node_id).rotation(),
             trajectory_data.imu_calibration.data());
       }
+
+      // Force gravity constant to be positive.
+      problem.SetParameterLowerBound(&trajectory_data.gravity_constant, 0, 0.0);
     }
   }
 


### PR DESCRIPTION
This makes sure gravity never flips the sign and becomes negative.

Signed-off-by: Wolfgang Hess <whess@lyft.com>