### PR TITLE
Add per-submap sampling.

### DIFF
--- a/cartographer/mapping/internal/constraints/constraint_builder_2d.h
+++ b/cartographer/mapping/internal/constraints/constraint_builder_2d.h
@@ -21,6 +21,7 @@
 #include <deque>
 #include <functional>
 #include <limits>
+#include <map>
 #include <vector>
 
 #include "Eigen/Core"
@@ -160,8 +161,8 @@ class ConstraintBuilder2D {
   // Map of dispatched or constructed scan matchers by 'submap_id'.
   std::map<SubmapId, SubmapScanMatcher> submap_scan_matchers_
       GUARDED_BY(mutex_);
+  std::map<SubmapId, common::FixedRatioSampler> per_submap_sampler_;
 
-  common::FixedRatioSampler sampler_;
   scan_matching::CeresScanMatcher2D ceres_scan_matcher_;
 
   // Histogram of scan matcher scores.

--- a/cartographer/mapping/internal/constraints/constraint_builder_3d.h
+++ b/cartographer/mapping/internal/constraints/constraint_builder_3d.h
@@ -21,6 +21,7 @@
 #include <deque>
 #include <functional>
 #include <limits>
+#include <map>
 #include <vector>
 
 #include "Eigen/Core"
@@ -169,8 +170,8 @@ class ConstraintBuilder3D {
   // Map of dispatched or constructed scan matchers by 'submap_id'.
   std::map<SubmapId, SubmapScanMatcher> submap_scan_matchers_
       GUARDED_BY(mutex_);
+  std::map<SubmapId, common::FixedRatioSampler> per_submap_sampler_;
 
-  common::FixedRatioSampler sampler_;
   scan_matching::CeresScanMatcher3D ceres_scan_matcher_;
 
   // Histograms of scan matcher scores.


### PR DESCRIPTION
This changes which submaps we select to attempt loop closing.
The subsampling of candidates is changing from randomly sampling
submap and node pairs to per-submap sampling. This enforces a
better distribution of loop closure attempts across the submaps.
This sampling achieves a much better performance which indicates
that the approach used before was sub-optimal.

Signed-off-by: Wolfgang Hess <whess@lyft.com>