### PR TITLE
Use intensities in `Submap3D` and `RangeDataInserter3D`.

### DIFF
--- a/cartographer/io/hybrid_grid_points_processor.cc
+++ b/cartographer/io/hybrid_grid_points_processor.cc
@@ -40,7 +40,8 @@ HybridGridPointsProcessor::FromDictionary(
 
 void HybridGridPointsProcessor::Process(std::unique_ptr<PointsBatch> batch) {
   range_data_inserter_.Insert(
-      {batch->origin, sensor::PointCloud(batch->points), {}}, &hybrid_grid_);
+      {batch->origin, sensor::PointCloud(batch->points), {}}, &hybrid_grid_,
+      /*intensity_hybrid_grid=*/nullptr);
   next_->Process(std::move(batch));
 }
 

--- a/cartographer/mapping/3d/range_data_inserter_3d.cc
+++ b/cartographer/mapping/3d/range_data_inserter_3d.cc
@@ -51,6 +51,21 @@ void InsertMissesIntoGrid(const std::vector<uint16>& miss_table,
   }
 }
 
+void InsertIntensitiesIntoGrid(const sensor::PointCloud& returns,
+                               IntensityHybridGrid* intensity_hybrid_grid,
+                               const float intensity_threshold) {
+  if (returns.intensities().size() > 0) {
+    for (size_t i = 0; i < returns.size(); ++i) {
+      if (returns.intensities()[i] > intensity_threshold) {
+        continue;
+      }
+      const Eigen::Array3i hit_cell =
+          intensity_hybrid_grid->GetCellIndex(returns[i].position);
+      intensity_hybrid_grid->AddIntensity(hit_cell, returns.intensities()[i]);
+    }
+  }
+}
+
 }  // namespace
 
 proto::RangeDataInserterOptions3D CreateRangeDataInserterOptions3D(
@@ -62,6 +77,8 @@ proto::RangeDataInserterOptions3D CreateRangeDataInserterOptions3D(
       parameter_dictionary->GetDouble("miss_probability"));
   options.set_num_free_space_voxels(
       parameter_dictionary->GetInt("num_free_space_voxels"));
+  options.set_intensity_threshold(
+      parameter_dictionary->GetDouble("intensity_threshold"));
   CHECK_GT(options.hit_probability(), 0.5);
   CHECK_LT(options.miss_probability(), 0.5);
   return options;
@@ -75,9 +92,10 @@ RangeDataInserter3D::RangeDataInserter3D(
       miss_table_(
           ComputeLookupTableToApplyOdds(Odds(options_.miss_probability()))) {}
 
-void RangeDataInserter3D::Insert(const sensor::RangeData& range_data,
-                                 HybridGrid* hybrid_grid) const {
-  CHECK(hybrid_grid != nullptr);
+void RangeDataInserter3D::Insert(
+    const sensor::RangeData& range_data, HybridGrid* hybrid_grid,
+    IntensityHybridGrid* intensity_hybrid_grid) const {
+  CHECK_NOTNULL(hybrid_grid);
 
   for (const sensor::RangefinderPoint& hit : range_data.returns) {
     const Eigen::Array3i hit_cell = hybrid_grid->GetCellIndex(hit.position);
@@ -88,6 +106,10 @@ void RangeDataInserter3D::Insert(const sensor::RangeData& range_data,
   // (i.e. no hits will be ignored because of a miss in the same cell).
   InsertMissesIntoGrid(miss_table_, range_data.origin, range_data.returns,
                        hybrid_grid, options_.num_free_space_voxels());
+  if (intensity_hybrid_grid != nullptr) {
+    InsertIntensitiesIntoGrid(range_data.returns, intensity_hybrid_grid,
+                              options_.intensity_threshold());
+  }
   hybrid_grid->FinishUpdate();
 }
 

--- a/cartographer/mapping/3d/range_data_inserter_3d.h
+++ b/cartographer/mapping/3d/range_data_inserter_3d.h
@@ -36,9 +36,10 @@ class RangeDataInserter3D {
   RangeDataInserter3D(const RangeDataInserter3D&) = delete;
   RangeDataInserter3D& operator=(const RangeDataInserter3D&) = delete;
 
-  // Inserts 'range_data' into 'hybrid_grid'.
-  void Insert(const sensor::RangeData& range_data,
-              HybridGrid* hybrid_grid) const;
+  // Inserts 'range_data' into 'hybrid_grid' and optionally into
+  // 'intensity_hybrid_grid'.
+  void Insert(const sensor::RangeData& range_data, HybridGrid* hybrid_grid,
+              IntensityHybridGrid* intensity_hybrid_grid) const;
 
  private:
   const proto::RangeDataInserterOptions3D options_;

--- a/cartographer/mapping/3d/submap_3d.cc
+++ b/cartographer/mapping/3d/submap_3d.cc
@@ -336,10 +336,10 @@ void ActiveSubmaps3D::AddSubmap(
     // This will crop the finished Submap before inserting a new Submap to
     // reduce peak memory usage a bit.
     CHECK(submaps_.front()->insertion_finished());
-    // We do `ForgetIntensityHybridGrid` in order to reduce memory usage.
-    // As we use active submaps, in particular intensity hybrid grids associated
-    // with them, for scan matching, thus we call `ForgetIntensityHybridGrid`
-    // only when we are about to remove the submap from active submaps.
+    // We use `ForgetIntensityHybridGrid` to reduce memory usage. Since we use
+    // active submaps and their associated intensity hybrid grids for scan
+    // matching, we call `ForgetIntensityHybridGrid` once we remove the submap
+    // from active submaps and no longer need the intensity hybrid grid.
     submaps_.front()->ForgetIntensityHybridGrid();
     submaps_.erase(submaps_.begin());
   }

--- a/cartographer/mapping/3d/submap_3d.h
+++ b/cartographer/mapping/3d/submap_3d.h
@@ -60,6 +60,14 @@ class Submap3D : public Submap {
   const HybridGrid& low_resolution_hybrid_grid() const {
     return *low_resolution_hybrid_grid_;
   }
+  const IntensityHybridGrid& high_resolution_intensity_hybrid_grid() const {
+    CHECK(high_resolution_intensity_hybrid_grid_ != nullptr);
+    return *high_resolution_intensity_hybrid_grid_;
+  }
+  void ForgetIntensityHybridGrid() {
+    high_resolution_intensity_hybrid_grid_.reset();
+  }
+
   const Eigen::VectorXf& rotational_scan_matcher_histogram() const {
     return rotational_scan_matcher_histogram_;
   }
@@ -79,6 +87,7 @@ class Submap3D : public Submap {
 
   std::unique_ptr<HybridGrid> high_resolution_hybrid_grid_;
   std::unique_ptr<HybridGrid> low_resolution_hybrid_grid_;
+  std::unique_ptr<IntensityHybridGrid> high_resolution_intensity_hybrid_grid_;
   Eigen::VectorXf rotational_scan_matcher_histogram_;
 };
 

--- a/cartographer/mapping/internal/3d/local_trajectory_builder_3d_test.cc
+++ b/cartographer/mapping/internal/3d/local_trajectory_builder_3d_test.cc
@@ -129,6 +129,7 @@ class LocalTrajectoryBuilderTest : public ::testing::Test {
               hit_probability = 0.7,
               miss_probability = 0.4,
               num_free_space_voxels = 0,
+              intensity_threshold = 100.0,
             },
           },
         }

--- a/cartographer/mapping/internal/3d/scan_matching/fast_correlative_scan_matcher_3d_test.cc
+++ b/cartographer/mapping/internal/3d/scan_matching/fast_correlative_scan_matcher_3d_test.cc
@@ -94,6 +94,7 @@ class FastCorrelativeScanMatcher3DTest : public ::testing::Test {
         "hit_probability = 0.7, "
         "miss_probability = 0.4, "
         "num_free_space_voxels = 5, "
+        "intensity_threshold = 100.0, "
         "}");
     return CreateRangeDataInserterOptions3D(parameter_dictionary.get());
   }
@@ -106,7 +107,8 @@ class FastCorrelativeScanMatcher3DTest : public ::testing::Test {
         sensor::RangeData{pose.translation(),
                           sensor::TransformPointCloud(point_cloud_, pose),
                           {}},
-        hybrid_grid_.get());
+        hybrid_grid_.get(),
+        /*intensity_hybrid_grid=*/nullptr);
     hybrid_grid_->FinishUpdate();
 
     return absl::make_unique<FastCorrelativeScanMatcher3D>(

--- a/cartographer/mapping/proto/range_data_inserter_options_3d.proto
+++ b/cartographer/mapping/proto/range_data_inserter_options_3d.proto
@@ -28,4 +28,7 @@ message RangeDataInserterOptions3D {
   // Up to how many free space voxels are updated for scan matching.
   // 0 disables free space.
   int32 num_free_space_voxels = 3;
+
+  // Do not insert intensities above this threshold into IntensityHybridGrid.
+  float intensity_threshold = 4;
 }

--- a/configuration_files/trajectory_builder_3d.lua
+++ b/configuration_files/trajectory_builder_3d.lua
@@ -13,6 +13,7 @@
 -- limitations under the License.
 
 MAX_3D_RANGE = 60.
+INTENSITY_THRESHOLD = 40
 
 TRAJECTORY_BUILDER_3D = {
   min_range = 1.,
@@ -96,6 +97,7 @@ TRAJECTORY_BUILDER_3D = {
       hit_probability = 0.55,
       miss_probability = 0.49,
       num_free_space_voxels = 2,
+      intensity_threshold = INTENSITY_THRESHOLD,
     },
   },
 }


### PR DESCRIPTION
`Submap3D` now also stores a pointer to `IntensityHybridGrid`.
Adapted `RangeDataInserter3D` to also insert intensities.

Signed-off-by: Wolfgang Hess <whess@lyft.com>