### PR TITLE
Clean trimming of frozen trajectory data.

### DIFF
--- a/cartographer/mapping/internal/2d/pose_graph_2d.cc
+++ b/cartographer/mapping/internal/2d/pose_graph_2d.cc
@@ -1210,28 +1210,24 @@ void PoseGraph2D::TrimmingHandle::TrimSubmap(const SubmapId& submap_id) {
   CHECK(parent_->data_.submap_data.at(submap_id).state ==
         SubmapState::kFinished);
 
-  std::set<NodeId> nodes_to_remove;
-  // We need to use node_ids instead of constraints here to be also compatible
-  // with frozen trajectories that don't have intra-constraints.
-  nodes_to_remove.insert(
-      parent_->data_.submap_data.at(submap_id).node_ids.begin(),
-      parent_->data_.submap_data.at(submap_id).node_ids.end());
-
   // Compile all nodes that are still INTRA_SUBMAP constrained to other submaps
   // once the submap with 'submap_id' is gone.
+  // We need to use node_ids instead of constraints here to be also compatible
+  // with frozen trajectories that don't have intra-constraints.
   std::set<NodeId> nodes_to_retain;
-  for (const auto& other_submap : parent_->data_.submap_data) {
-    if (other_submap.id == submap_id) {
-      continue;
+  for (const auto& submap_data : parent_->data_.submap_data) {
+    if (submap_data.id != submap_id) {
+      nodes_to_retain.insert(submap_data.data.node_ids.begin(),
+                             submap_data.data.node_ids.end());
     }
-    std::set_intersection(
-        nodes_to_remove.begin(), nodes_to_remove.end(),
-        other_submap.data.node_ids.begin(), other_submap.data.node_ids.end(),
-        std::inserter(nodes_to_retain, nodes_to_retain.begin()));
   }
-  for (const auto& node_to_retain : nodes_to_retain) {
-    nodes_to_remove.erase(node_to_retain);
-  }
+
+  // Remove all nodes that are exlusively associated to 'submap_id'.
+  std::set<NodeId> nodes_to_remove;
+  std::set_difference(parent_->data_.submap_data.at(submap_id).node_ids.begin(),
+                      parent_->data_.submap_data.at(submap_id).node_ids.end(),
+                      nodes_to_retain.begin(), nodes_to_retain.end(),
+                      std::inserter(nodes_to_remove, nodes_to_remove.begin()));
 
   // Remove all 'data_.constraints' related to 'submap_id'.
   {

--- a/cartographer/mapping/internal/2d/pose_graph_2d.cc
+++ b/cartographer/mapping/internal/2d/pose_graph_2d.cc
@@ -1237,6 +1237,26 @@ void PoseGraph2D::TrimmingHandle::TrimSubmap(const SubmapId& submap_id) {
     }
     parent_->data_.constraints = std::move(constraints);
   }
+
+  // A frozen trajectory needs special care because there we can't identify the
+  // nodes_to_remove based on optimization constraints (it doesn't have them).
+  if (parent_->IsTrajectoryFrozen(submap_id.trajectory_id)) {
+    // Remove node_ids that are associated with the frozen submap to be trimmed.
+    nodes_to_remove.insert(
+        parent_->data_.submap_data.at(submap_id).node_ids.begin(),
+        parent_->data_.submap_data.at(submap_id).node_ids.end());
+    // Retain overlapping nodes that are also associated with other submaps.
+    for (const auto& other_submap : parent_->data_.submap_data) {
+      if (other_submap.id == submap_id) {
+        continue;
+      }
+      std::set_intersection(
+          nodes_to_remove.begin(), nodes_to_remove.end(),
+          other_submap.data.node_ids.begin(), other_submap.data.node_ids.end(),
+          std::inserter(nodes_to_retain, nodes_to_retain.begin()));
+    }
+  }
+
   // Remove all 'data_.constraints' related to 'nodes_to_remove'.
   // If the removal lets other submaps lose all their inter-submap constraints,
   // delete their corresponding constraint submap matchers to save memory.
@@ -1290,6 +1310,9 @@ void PoseGraph2D::TrimmingHandle::TrimSubmap(const SubmapId& submap_id) {
   // Remove the 'nodes_to_remove' from the pose graph and the optimization
   // problem.
   for (const NodeId& node_id : nodes_to_remove) {
+    if (nodes_to_retain.count(node_id)) {
+      continue;
+    }
     parent_->data_.trajectory_nodes.Trim(node_id);
     parent_->optimization_problem_->TrimTrajectoryNode(node_id);
   }

--- a/cartographer/mapping/internal/3d/pose_graph_3d.cc
+++ b/cartographer/mapping/internal/3d/pose_graph_3d.cc
@@ -1190,51 +1190,38 @@ void PoseGraph3D::TrimmingHandle::TrimSubmap(const SubmapId& submap_id) {
   CHECK(parent_->data_.submap_data.at(submap_id).state ==
         SubmapState::kFinished);
 
-  // Compile all nodes that are still INTRA_SUBMAP constrained once the submap
-  // with 'submap_id' is gone.
-  std::set<NodeId> nodes_to_retain;
-  for (const Constraint& constraint : parent_->data_.constraints) {
-    if (constraint.tag == Constraint::Tag::INTRA_SUBMAP &&
-        constraint.submap_id != submap_id) {
-      nodes_to_retain.insert(constraint.node_id);
-    }
-  }
-  // Remove all 'data_.constraints' related to 'submap_id'.
   std::set<NodeId> nodes_to_remove;
+  // We need to use node_ids instead of constraints here to be also compatible
+  // with frozen trajectories that don't have intra-constraints.
+  nodes_to_remove.insert(
+      parent_->data_.submap_data.at(submap_id).node_ids.begin(),
+      parent_->data_.submap_data.at(submap_id).node_ids.end());
+
+  // Compile all nodes that are still INTRA_SUBMAP constrained to other submaps
+  // once the submap with 'submap_id' is gone.
+  std::set<NodeId> nodes_to_retain;
+  for (const auto& other_submap : parent_->data_.submap_data) {
+    if (other_submap.id == submap_id) {
+      continue;
+    }
+    std::set_intersection(
+        nodes_to_remove.begin(), nodes_to_remove.end(),
+        other_submap.data.node_ids.begin(), other_submap.data.node_ids.end(),
+        std::inserter(nodes_to_retain, nodes_to_retain.begin()));
+  }
+  for (const auto& node_to_retain : nodes_to_retain) {
+    nodes_to_remove.erase(node_to_retain);
+  }
+
+  // Remove all 'data_.constraints' related to 'submap_id'.
   {
     std::vector<Constraint> constraints;
     for (const Constraint& constraint : parent_->data_.constraints) {
-      if (constraint.submap_id == submap_id) {
-        if (constraint.tag == Constraint::Tag::INTRA_SUBMAP &&
-            nodes_to_retain.count(constraint.node_id) == 0) {
-          // This node will no longer be INTRA_SUBMAP contrained and has to be
-          // removed.
-          nodes_to_remove.insert(constraint.node_id);
-        }
-      } else {
+      if (constraint.submap_id != submap_id) {
         constraints.push_back(constraint);
       }
     }
     parent_->data_.constraints = std::move(constraints);
-  }
-
-  // A frozen trajectory needs special care because there we can't identify the
-  // nodes_to_remove based on optimization constraints (it doesn't have them).
-  if (parent_->IsTrajectoryFrozen(submap_id.trajectory_id)) {
-    // Remove node_ids that are associated with the frozen submap to be trimmed.
-    nodes_to_remove.insert(
-        parent_->data_.submap_data.at(submap_id).node_ids.begin(),
-        parent_->data_.submap_data.at(submap_id).node_ids.end());
-    // Retain overlapping nodes that are also associated with other submaps.
-    for (const auto& other_submap : parent_->data_.submap_data) {
-      if (other_submap.id == submap_id) {
-        continue;
-      }
-      std::set_intersection(
-          nodes_to_remove.begin(), nodes_to_remove.end(),
-          other_submap.data.node_ids.begin(), other_submap.data.node_ids.end(),
-          std::inserter(nodes_to_retain, nodes_to_retain.begin()));
-    }
   }
 
   // Remove all 'data_.constraints' related to 'nodes_to_remove'.
@@ -1290,9 +1277,6 @@ void PoseGraph3D::TrimmingHandle::TrimSubmap(const SubmapId& submap_id) {
   // Remove the 'nodes_to_remove' from the pose graph and the optimization
   // problem.
   for (const NodeId& node_id : nodes_to_remove) {
-    if (nodes_to_retain.count(node_id)) {
-      continue;
-    }
     parent_->data_.trajectory_nodes.Trim(node_id);
     parent_->optimization_problem_->TrimTrajectoryNode(node_id);
   }

--- a/cartographer/mapping/map_builder.cc
+++ b/cartographer/mapping/map_builder.cc
@@ -359,7 +359,7 @@ std::map<int, int> MapBuilder::LoadState(
 
   if (load_frozen_state) {
     // Add information about which nodes belong to which submap.
-    // Required for 3D pure localization.
+    // This is required, even without constraints.
     for (const proto::PoseGraph::Constraint& constraint_proto :
          pose_graph_proto.constraint()) {
       if (constraint_proto.tag() !=


### PR DESCRIPTION
The deletion logic needs to take care of deleting all data that is
"exclusively" connected to the submaps that are to be removed. This is
achieved by looking at the data that is connected via constraints in
the graph.

Deleting a frozen trajectory (one without optimization constraints)
doesn't work that way and would leave dangling nodes in the graph.

This modifies the logic to use the `node_ids` field of the submap
instead of the constraints.

Signed-off-by: Michael Grupp <grupp@magazino.eu>