### PR TITLE
Add missing virtual destructors, fix #1771

### DIFF
--- a/cartographer/mapping/2d/grid_2d.h
+++ b/cartographer/mapping/2d/grid_2d.h
@@ -42,6 +42,7 @@ class Grid2D : public GridInterface {
          ValueConversionTables* conversion_tables);
   explicit Grid2D(const proto::Grid2D& proto,
                   ValueConversionTables* conversion_tables);
+  virtual ~Grid2D() {}
 
   // Returns the limits of this Grid2D.
   const MapLimits& limits() const { return limits_; }

--- a/cartographer/mapping/2d/probability_grid.h
+++ b/cartographer/mapping/2d/probability_grid.h
@@ -34,6 +34,7 @@ class ProbabilityGrid : public Grid2D {
                            ValueConversionTables* conversion_tables);
   explicit ProbabilityGrid(const proto::Grid2D& proto,
                            ValueConversionTables* conversion_tables);
+  virtual ~ProbabilityGrid() {}
 
   // Sets the probability of the cell at 'cell_index' to the given
   // 'probability'. Only allowed if the cell was unknown before.

--- a/cartographer/mapping/2d/probability_grid_range_data_inserter_2d.h
+++ b/cartographer/mapping/2d/probability_grid_range_data_inserter_2d.h
@@ -40,6 +40,7 @@ class ProbabilityGridRangeDataInserter2D : public RangeDataInserterInterface {
  public:
   explicit ProbabilityGridRangeDataInserter2D(
       const proto::ProbabilityGridRangeDataInserterOptions2D& options);
+  virtual ~ProbabilityGridRangeDataInserter2D() {}
 
   ProbabilityGridRangeDataInserter2D(
       const ProbabilityGridRangeDataInserter2D&) = delete;

--- a/cartographer/mapping/range_data_inserter_interface.h
+++ b/cartographer/mapping/range_data_inserter_interface.h
@@ -37,6 +37,8 @@ class RangeDataInserterInterface {
   // Inserts 'range_data' into 'grid'.
   virtual void Insert(const sensor::RangeData& range_data,
                       GridInterface* grid) const = 0;
+
+  virtual ~RangeDataInserterInterface() {}
 };
 
 }  // namespace mapping


### PR DESCRIPTION
Signed-off-by: Tobias Fischer <info@tobiasfischer.info>

See #1771

Successfully fixed the test failures on osx on conda-forge & compiler does not complain anymore (previous warning example: `warning: delete called on 'cartographer::mapping::Grid2D' that is abstract but has non-virtual destructor [-Wdelete-abstract-non-virtual-dtor]`.