### PR TITLE
Improve CONTRIBUTING.md and the pull request template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,2 @@
-Want to contribute? Great! Make sure you've read, understood and considered all
-the points below before creating your PR:
-
-- Keep your PR under 200 lines of code and address a single concern.
-- Add unit test(s) and documentation (these do not count toward your 200 lines).
-- Adhere to the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html).
-- Run `ninja test` or `catkin_make_isolated --install --use-ninja --pkg cartographer --make-args test` as appropriate.
-- Keep rebasing (or merging) of master branch to a minimum. It triggers Travis
-  runs for every update which blocks merging of other changes. Our merge bot
-  will rebase your branch, reformat your source code and merge as the last step
-  in the review process.
-- Please replace this template text with the commit message you want for your
-  PR. You and/or the reviewer should keep it updated during the course of the
-  review using the GitHub edit feature.
+Want to contribute? Great! Make sure you've read and understood
+[CONTRIBUTING.md](https://github.com/cartographer-project/cartographer/blob/master/CONTRIBUTING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,4 +27,25 @@ You can sign-off a commit via `git commit -s`.
 ### Code reviews
 
 All submissions, including submissions by project members, require review.
-We use GitHub pull requests for this purpose.
+We use GitHub pull requests for this purpose. Make sure you've read,
+understood and considered all the points below before creating your PR.
+
+#### Style guide
+
+C++ code should adhere to the
+[Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html).
+You can handle the formatting part of the style guide via `git clang-format`.
+
+#### Best practices
+
+When preparing your PR and also during the code review make sure to follow
+[best practices](https://google.github.io/eng-practices/review/developer/).
+Most importantly, keep your PR under 200 lines of code and address a single
+concern.
+
+#### Testing
+
+- Add unit tests and documentation (these do not count toward your 200 lines).
+- Run `ninja test` or `catkin_make_isolated --install --use-ninja --pkg cartographer --make-args test` as appropriate.
+- Keep rebasing (or merging) of master branch to a minimum. It triggers Travis
+  runs for every update which blocks merging of other changes.


### PR DESCRIPTION
We refer to CONTRIBUTING.md from the PR template now
which is now the single place containing all information.

Reference to the bot is removed since it is currently
not being used.

We point contributors to using clang-format.

We link to PR and code review best practices now.

Signed-off-by: Wolfgang Hess <whess@lyft.com>