### PR TITLE
Move PoseGraph::GetSubmapData to the PoseGraphInterface.

### DIFF
--- a/cartographer/cloud/internal/client/pose_graph_stub.cc
+++ b/cartographer/cloud/internal/client/pose_graph_stub.cc
@@ -52,6 +52,11 @@ PoseGraphStub::GetAllSubmapData() const {
   LOG(FATAL) << "Not implemented";
 }
 
+mapping::PoseGraphInterface::SubmapData PoseGraphStub::GetSubmapData(
+    const mapping::SubmapId& submap_id) const {
+  LOG(FATAL) << "Not implemented";
+}
+
 mapping::MapById<mapping::SubmapId, mapping::PoseGraphInterface::SubmapPose>
 PoseGraphStub::GetAllSubmapPoses() const {
   google::protobuf::Empty request;

--- a/cartographer/cloud/internal/client/pose_graph_stub.h
+++ b/cartographer/cloud/internal/client/pose_graph_stub.h
@@ -34,6 +34,7 @@ class PoseGraphStub : public ::cartographer::mapping::PoseGraphInterface {
   void RunFinalOptimization() override;
   mapping::MapById<mapping::SubmapId, SubmapData> GetAllSubmapData()
       const override;
+  SubmapData GetSubmapData(const mapping::SubmapId& submap_id) const override;
   mapping::MapById<mapping::SubmapId, SubmapPose> GetAllSubmapPoses()
       const override;
   transform::Rigid3d GetLocalToGlobalTransform(

--- a/cartographer/mapping/internal/testing/mock_pose_graph.h
+++ b/cartographer/mapping/internal/testing/mock_pose_graph.h
@@ -34,6 +34,7 @@ class MockPoseGraph : public mapping::PoseGraphInterface {
   MOCK_METHOD0(RunFinalOptimization, void());
   MOCK_CONST_METHOD0(GetAllSubmapData,
                      mapping::MapById<mapping::SubmapId, SubmapData>());
+  MOCK_CONST_METHOD1(GetSubmapData, SubmapData(const SubmapId&));
   MOCK_CONST_METHOD0(GetAllSubmapPoses,
                      mapping::MapById<mapping::SubmapId, SubmapPose>());
   MOCK_CONST_METHOD1(GetLocalToGlobalTransform, transform::Rigid3d(int));

--- a/cartographer/mapping/pose_graph.h
+++ b/cartographer/mapping/pose_graph.h
@@ -112,11 +112,6 @@ class PoseGraph : public PoseGraphInterface {
   // Gets the current trajectory clusters.
   virtual std::vector<std::vector<int>> GetConnectedTrajectories() const = 0;
 
-  // Returns the current optimized transform and submap itself for the given
-  // 'submap_id'. Returns 'nullptr' for the 'submap' member if the submap does
-  // not exist (anymore).
-  virtual SubmapData GetSubmapData(const SubmapId& submap_id) const = 0;
-
   proto::PoseGraph ToProto(bool include_unfinished_submaps) const override;
 
   // Returns the IMU data.

--- a/cartographer/mapping/pose_graph_interface.h
+++ b/cartographer/mapping/pose_graph_interface.h
@@ -99,6 +99,11 @@ class PoseGraphInterface {
   // Returns data for all submaps.
   virtual MapById<SubmapId, SubmapData> GetAllSubmapData() const = 0;
 
+  // Returns the current optimized transform and submap itself for the given
+  // 'submap_id'. Returns 'nullptr' for the 'submap' member if the submap does
+  // not exist (anymore).
+  virtual SubmapData GetSubmapData(const SubmapId& submap_id) const = 0;
+
   // Returns the global poses for all submaps.
   virtual MapById<SubmapId, SubmapPose> GetAllSubmapPoses() const = 0;
 


### PR DESCRIPTION
Related to #1413.

Signed-off-by: Wolfgang Hess <whess@lyft.com>