### PR TITLE
Remove CHECK preventing the use of the IMU-based extrapolator.

### DIFF
--- a/cartographer/mapping/pose_extrapolator_interface.cc
+++ b/cartographer/mapping/pose_extrapolator_interface.cc
@@ -84,8 +84,6 @@ PoseExtrapolatorInterface::CreateWithImuData(
     const std::vector<sensor::ImuData>& imu_data,
     const std::vector<transform::TimestampedTransform>& initial_poses) {
   CHECK(!imu_data.empty());
-  // TODO(schwoere): Implement/integrate imu based extrapolator.
-  CHECK(!options.use_imu_based()) << "Not implemented!";
   if (options.use_imu_based()) {
     return ImuBasedPoseExtrapolator::InitializeWithImu(options.imu_based(),
                                                        imu_data, initial_poses);


### PR DESCRIPTION
Fixes #1803.

Signed-off-by: Wolfgang Hess <whess@lyft.com>