### PR TITLE
Remove ubuntu1604 from presubmit.yml

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,7 +1,7 @@
 ---
 platforms:
-  ubuntu1604:
+  ubuntu1804:
     build_targets:
-    - "..."
+    - "//..."
     test_targets:
-    - "..."
+    - "//..."


### PR DESCRIPTION
Ubuntu 16.04 is end-of-life, we're going to remove it from Bazel CI.

If you like you can add testing on `ubuntu2004` platform which we also support.
