### PR TITLE
Add std::move to ImuBasedPoseExtrapolator function return explicitly

### DIFF
--- a/cartographer/mapping/internal/imu_based_pose_extrapolator.cc
+++ b/cartographer/mapping/internal/imu_based_pose_extrapolator.cc
@@ -68,7 +68,7 @@ ImuBasedPoseExtrapolator::InitializeWithImu(
         transform::Rigid3d::Rotation(FromTwoVectors(
             imu_data.back().linear_acceleration, Eigen::Vector3d::UnitZ())));
   }
-  return extrapolator;
+  return std::move(extrapolator);
 }
 
 common::Time ImuBasedPoseExtrapolator::GetLastPoseTime() const {

--- a/scripts/install_debs_bazel.sh
+++ b/scripts/install_debs_bazel.sh
@@ -27,7 +27,7 @@ sudo apt-get install -y \
     zlib1g-dev \
     unzip \
     python
-wget https://github.com/bazelbuild/bazel/releases/download/0.9.0/bazel-0.9.0-installer-linux-x86_64.sh
-chmod +x bazel-0.9.0-installer-linux-x86_64.sh
-./bazel-0.9.0-installer-linux-x86_64.sh
+wget https://github.com/bazelbuild/bazel/releases/download/4.2.1/bazel-4.2.1-installer-linux-x86_64.sh
+chmod +x bazel-4.2.1-installer-linux-x86_64.sh
+./bazel-4.2.1-installer-linux-x86_64.sh
 export PATH="$PATH:$HOME/bin"


### PR DESCRIPTION
Adds `std::move` to `ImuBasedPoseExtrapolator` function return explicitly to show copy elision is not performed. 
Also changes version of bazel for docker. 
Fixes: #1852 