### PR TITLE
Fix typo in trajectory_builder_3d.lua

### DIFF
--- a/configuration_files/trajectory_builder_3d.lua
+++ b/configuration_files/trajectory_builder_3d.lua
@@ -106,7 +106,7 @@ TRAJECTORY_BUILDER_3D = {
     },
   },
 
-  -- When setting use_intensites to true, the intensity_cost_function_options_0
+  -- When setting use_intensities to true, the intensity_cost_function_options_0
   -- parameter in ceres_scan_matcher has to be set up as well or otherwise
   -- CeresScanMatcher will CHECK-fail.
   use_intensities = false,


### PR DESCRIPTION
Just fix the comment (`use_intensites` -> `use_intensities`)

Signed-off-by: Takashi Ogura <t.ogura@gmail.com>