### PR TITLE
Update .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -21,3 +21,4 @@ build -c opt
 # reduces build time.
 build --force_pic
 
+build --incompatible_disallow_empty_glob


### PR DESCRIPTION
Make sure that no regressions are introduced to build with incompatible_disallow_empty_glob
